### PR TITLE
Added power support for the travis.yml file with ppc64le. and excluded the jobs go version 1.3.x,1.4.x on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,10 @@ go:
   - '1.9.x'
   - '1.10.x'
   - 'tip'
+# Disable Go version 1.3.x,1.34.x 
+jobs:
+  exclude:
+    - arch: ppc64le
+      go: 1.3.x
+    - arch: ppc64le 
+      go: 1.4.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch:
+  - amd64
+  - ppc64le
 go:
   - '1.3.x'
   - '1.4.x'


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing
excluded the jobs go version 1.3.x,1.4.x on ppc64le