### PR TITLE
use generics for shuffling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/shogo82148/go-shuffle
 
-go 1.16
+go 1.18

--- a/interface.go
+++ b/interface.go
@@ -5,6 +5,7 @@ package shuffle
 
 import (
 	"math/rand"
+	"sort"
 )
 
 // Interface is a type, typically a collection, that satisfies shuffle.Interface can be
@@ -24,7 +25,7 @@ func (p Int64Slice) Less(i, j int) bool { return p[i] < p[j] }
 func (p Int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // SortInt64s sorts a slice of int64s in increasing order.
-func SortInt64s(a []int64) { shuffleSlice(a) }
+func SortInt64s(a []int64) { sort.Sort(Int64Slice(a)) }
 
 // Ints shuffles a slice of ints.
 func Ints(a []int) { shuffleSlice(a) }

--- a/interface_go1.17.go
+++ b/interface_go1.17.go
@@ -1,11 +1,9 @@
-//go:build go1.18
-// +build go1.18
+//go:build !go1.18
+// +build !go1.18
 
 package shuffle
 
-import (
-	"math/rand"
-)
+import "sort"
 
 // Interface is a type, typically a collection, that satisfies shuffle.Interface can be
 // shuffled by the routines in this package.
@@ -24,23 +22,16 @@ func (p Int64Slice) Less(i, j int) bool { return p[i] < p[j] }
 func (p Int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // SortInt64s sorts a slice of int64s in increasing order.
-func SortInt64s(a []int64) { shuffleSlice(a) }
+func SortInt64s(a []int64) { sort.Sort(Int64Slice(a)) }
 
 // Ints shuffles a slice of ints.
-func Ints(a []int) { shuffleSlice(a) }
+func Ints(a []int) { Shuffle(sort.IntSlice(a)) }
 
 // Int64s shuffles a slice of int64s.
-func Int64s(a []int64) { shuffleSlice(a) }
+func Int64s(a []int64) { Shuffle(Int64Slice(a)) }
 
 // Float64s shuffles a slice of float64s.
-func Float64s(a []float64) { shuffleSlice(a) }
+func Float64s(a []float64) { Shuffle(sort.Float64Slice(a)) }
 
 // Strings shuffles a slice of strings.
-func Strings(a []string) { shuffleSlice(a) }
-
-func shuffleSlice[T any](a []T) {
-	for i := len(a) - 1; i >= 0; i-- {
-		j := rand.Intn(i + 1)
-		a[i], a[j] = a[j], a[i]
-	}
-}
+func Strings(a []string) { Shuffle(sort.StringSlice(a)) }

--- a/shuffle_go1.17.go
+++ b/shuffle_go1.17.go
@@ -1,5 +1,5 @@
-//go:build go1.18
-// +build go1.18
+//go:build go1.10 && !go1.18
+// +build go1.10,!go1.18
 
 // Package shuffle provides primitives for shuffling slices and user-defined
 // collections.
@@ -37,7 +37,7 @@ func (s *Shuffler) Shuffle(data Interface) {
 //
 // As of Go 1.10, it just calls (*rand.Rand).Shuffle(len(a), func(i, j int) { a[i], a[j] = a[j], a[i]}).
 func (s *Shuffler) Ints(a []int) {
-	shuffleGeneric((*rand.Rand)(s), a)
+	(*rand.Rand)(s).Shuffle(len(a), func(i, j int) { a[i], a[j] = a[j], a[i] })
 }
 
 // Float64s shuffles a slice of float64s.
@@ -52,11 +52,4 @@ func (s *Shuffler) Float64s(a []float64) {
 // As of Go 1.10, it just calls (*rand.Rand).Shuffle(len(a), func(i, j int) { a[i], a[j] = a[j], a[i]}).
 func (s *Shuffler) Strings(a []string) {
 	(*rand.Rand)(s).Shuffle(len(a), func(i, j int) { a[i], a[j] = a[j], a[i] })
-}
-
-func shuffleGeneric[T any](r *rand.Rand, a []T) {
-	for i := len(a) - 1; i >= 0; i++ {
-		j := r.Intn(i + 1)
-		a[i], a[j] = a[j], a[i]
-	}
 }


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-shuffle
cpu: Apple M1 Pro
                            │   .old.txt   │              .new.txt               │
                            │    sec/op    │   sec/op     vs base                │
Ints/shuffle_1-10             24.205n ± 1%   8.847n ± 1%  -63.45% (p=0.000 n=10)
Ints/perm_1-10                 17.31n ± 6%   17.09n ± 0%   -1.27% (p=0.000 n=10)
Ints/perm_and_move_1-10        17.89n ± 1%   17.73n ± 0%   -0.89% (p=0.002 n=10)
Ints/shuffle_10-10            103.55n ± 1%   82.86n ± 0%  -19.98% (p=0.000 n=10)
Ints/perm_10-10                89.00n ± 1%   88.30n ± 1%   -0.79% (p=0.001 n=10)
Ints/perm_and_move_10-10       99.06n ± 2%   97.97n ± 0%   -1.11% (p=0.002 n=10)
Ints/shuffle_100-10            766.2n ± 1%   819.2n ± 1%   +6.92% (p=0.000 n=10)
Ints/perm_100-10               771.0n ± 4%   770.0n ± 2%        ~ (p=0.987 n=10)
Ints/perm_and_move_100-10      821.9n ± 2%   829.9n ± 1%        ~ (p=0.197 n=10)
Ints/shuffle_1000-10           7.544µ ± 4%   7.823µ ± 8%   +3.69% (p=0.004 n=10)
Ints/perm_1000-10              7.460µ ± 2%   7.262µ ± 1%   -2.65% (p=0.012 n=10)
Ints/perm_and_move_1000-10     7.975µ ± 3%   7.750µ ± 1%   -2.82% (p=0.000 n=10)
Ints/shuffle_10000-10          74.93µ ± 4%   78.00µ ± 2%   +4.10% (p=0.002 n=10)
Ints/perm_10000-10             72.02µ ± 3%   72.26µ ± 1%        ~ (p=0.853 n=10)
Ints/perm_and_move_10000-10    75.59µ ± 3%   76.11µ ± 2%        ~ (p=0.247 n=10)
geomean                        967.4n        895.2n        -7.46%

                            │   .old.txt   │                 .new.txt                  │
                            │     B/op     │     B/op      vs base                     │
Ints/shuffle_1-10               24.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_1-10                  8.000 ± 0%     8.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_1-10         8.000 ± 0%     8.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_10-10              24.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_10-10                 80.00 ± 0%     80.00 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_10-10        80.00 ± 0%     80.00 ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_100-10             24.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_100-10                896.0 ± 0%     896.0 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_100-10       896.0 ± 0%     896.0 ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_1000-10            24.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_1000-10             8.000Ki ± 0%   8.000Ki ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_1000-10    8.000Ki ± 0%   8.000Ki ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_10000-10          29.000 ± 0%     5.000 ± 0%   -82.76% (p=0.000 n=10)
Ints/perm_10000-10            80.00Ki ± 0%   80.00Ki ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_10000-10   80.01Ki ± 0%   80.01Ki ± 0%         ~ (p=1.000 n=10)
geomean                         257.2                      ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                            │  .old.txt  │                .new.txt                 │
                            │ allocs/op  │ allocs/op   vs base                     │
Ints/shuffle_1-10             1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_1-10                1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_1-10       1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_10-10            1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_10-10               1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_10-10      1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_100-10           1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_100-10              1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_100-10     1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_1000-10          1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_1000-10             1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_1000-10    1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/shuffle_10000-10         1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Ints/perm_10000-10            1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
Ints/perm_and_move_10000-10   1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                       1.000                    ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the project to utilize Go version 1.18, enabling access to new language features and improvements.
	- Introduced a generic function for shuffling slices, enhancing code reusability and maintainability.
	- Added a new package providing shuffling functionality for various data types, simplifying shuffling operations.

- **Bug Fixes**
	- Streamlined shuffling methods to reduce redundancy and improve performance.

- **Documentation**
	- Improved internal documentation for the new shuffling interfaces and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->