### PR TITLE
drop Int64Slice

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -2,7 +2,6 @@ package shuffle
 
 import (
 	"math/rand/v2"
-	"sort"
 )
 
 // Interface is a type, typically a collection, that satisfies shuffle.Interface can be
@@ -14,21 +13,8 @@ type Interface interface {
 	Swap(i, j int)
 }
 
-// Int64Slice attaches the methods of Interface to []int64, sorting in increasing order.
-type Int64Slice []int64
-
-func (p Int64Slice) Len() int           { return len(p) }
-func (p Int64Slice) Less(i, j int) bool { return p[i] < p[j] }
-func (p Int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
-// SortInt64s sorts a slice of int64s in increasing order.
-func SortInt64s(a []int64) { sort.Sort(Int64Slice(a)) }
-
 // Ints shuffles a slice of ints.
 func Ints(a []int) { shuffleSlice(a) }
-
-// Int64s shuffles a slice of int64s.
-func Int64s(a []int64) { shuffleSlice(a) }
 
 // Float64s shuffles a slice of float64s.
 func Float64s(a []float64) { shuffleSlice(a) }

--- a/shuffle_test.go
+++ b/shuffle_test.go
@@ -24,22 +24,3 @@ func TestShuffle(t *testing.T) {
 		t.Errorf("got %v\nwant %v", a, b)
 	}
 }
-
-func TestShuffleInt64Slice(t *testing.T) {
-	a := make([]int64, 20)
-	b := make([]int64, len(a))
-	for i := 0; i < len(a); i++ {
-		a[i] = int64(i)
-		b[i] = int64(i)
-	}
-
-	Int64s(a)
-	if reflect.DeepEqual(a, b) {
-		t.Errorf("%v has not been shuffled", a)
-	}
-
-	SortInt64s(a)
-	if !reflect.DeepEqual(a, b) {
-		t.Errorf("got %v\nwant %v", a, b)
-	}
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the shuffle package to exclusively focus on shuffling capabilities for slices of `int` and `float64`.

- **Bug Fixes**
	- Removed sorting functionality for `int64` slices, which may impact applications previously relying on this feature.

- **Tests**
	- Eliminated the test for shuffling `int64` slices, reflecting the removal of sorting tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->